### PR TITLE
Tt 129 include carma time lib installation in mmitss dockerfile

### DIFF
--- a/mmitss/build/dockerfiles/x86/Dockerfile.carma_time_lib
+++ b/mmitss/build/dockerfiles/x86/Dockerfile.carma_time_lib
@@ -1,37 +1,40 @@
 #-----------------------------------------------------------------------------#
 #    Dockerfile to build an arm platform image for carma intersection         #
-#    Image name: mmitssuarizona/mmitss-carma-mrp-arm                          # 
+#    Image name: mmitssuarizona/mmitss-carma-mrp-arm                          #
 #-----------------------------------------------------------------------------#
 FROM mmitssuarizona/mmitss-x86-base:2.1
 MAINTAINER S Cornejo (samuelcornejo@arizona.edu)
 
-
-RUN apt update && apt install -y curl lsb-release cmake
-
-
-RUN . /etc/lsb-release
-RUN echo "deb [trusted=yes] http://s3.amazonaws.com/stol-apt-repository ${DISTRIB_CODENAME} main" | tee /etc/apt/sources.list.d/stol-apt-repository.list > /dev/null 
-
-RUN apt update
-RUN apt install carma-clock-1
-
-
+# Install dependencies
 RUN apt-get update && apt-get install -y \
+    curl \
+    lsb-release \
+    cmake \
     git \
     bash \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# Add stol-apt-repository
+RUN . /etc/lsb-release && \
+    echo "deb [trusted=yes] http://s3.amazonaws.com/stol-apt-repository ${DISTRIB_CODENAME} main" | \
+    tee /etc/apt/sources.list.d/stol-apt-repository.list > /dev/null
+
+RUN apt-get update && apt-get install -y carma-clock-1
+
+# Clone carma-time-lib repository
 WORKDIR /root/dev_ws/src
 RUN git clone https://github.com/usdot-fhwa-stol/carma-time-lib.git -b develop
-WORKDIR /carma-time-lib
 
-RUN chmod +x ./install_dependencies.sh
-RUN cmake -Bbuild -DBUILD_PYTHON_BINDINGS=ON .
-RUN cmake --build build
+WORKDIR /root/dev_ws/src/carma-time-lib
 
+# Run the install script and build with CMake
+RUN chmod +x ./install_dependencies.sh && ./install_dependencies.sh
+RUN cmake -Bbuild -DBUILD_PYTHON_BINDINGS=ON . && \
+    cmake --build build --target install
 
+# Copy additional files
 ADD cda-mmitss /cda-mmitss
 
-ENTRYPOINT ["/usr/bin/supervisord", "--configuration=/nojournal/bin/supervisord.conf"]
-
+# Supervisord for managing services
+CMD ["/usr/bin/supervisord", "--configuration=/nojournal/bin/supervisord.conf"]

--- a/mmitss/build/dockerfiles/x86/Dockerfile.carma_time_lib
+++ b/mmitss/build/dockerfiles/x86/Dockerfile.carma_time_lib
@@ -1,6 +1,6 @@
 #-----------------------------------------------------------------------------#
 #    Dockerfile to build an arm platform image for carma intersection         #
-#    Image name: mmitssuarizona/mmitss-carma-mrp-arm                          #
+#    Image name: mmitssuarizona/mmitss-carma-time-lib                          #
 #-----------------------------------------------------------------------------#
 FROM mmitssuarizona/mmitss-x86-base:2.1
 MAINTAINER S Cornejo (samuelcornejo@arizona.edu)
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     git \
     bash \
+    python3-dev \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
@@ -33,8 +34,8 @@ RUN chmod +x ./install_dependencies.sh && ./install_dependencies.sh
 RUN cmake -Bbuild -DBUILD_PYTHON_BINDINGS=ON . && \
     cmake --build build --target install
 
-# Copy additional files
-ADD cda-mmitss /cda-mmitss
+# # Copy additional files
+# ADD cda-mmitss /cda-mmitss
 
 # Supervisord for managing services
 CMD ["/usr/bin/supervisord", "--configuration=/nojournal/bin/supervisord.conf"]

--- a/mmitss/build/dockerfiles/x86/Dockerfile.carma_time_lib
+++ b/mmitss/build/dockerfiles/x86/Dockerfile.carma_time_lib
@@ -1,0 +1,37 @@
+#-----------------------------------------------------------------------------#
+#    Dockerfile to build an arm platform image for carma intersection         #
+#    Image name: mmitssuarizona/mmitss-carma-mrp-arm                          # 
+#-----------------------------------------------------------------------------#
+FROM mmitssuarizona/mmitss-x86-base:2.1
+MAINTAINER S Cornejo (samuelcornejo@arizona.edu)
+
+
+RUN apt update && apt install -y curl lsb-release cmake
+
+
+RUN . /etc/lsb-release
+RUN echo "deb [trusted=yes] http://s3.amazonaws.com/stol-apt-repository ${DISTRIB_CODENAME} main" | tee /etc/apt/sources.list.d/stol-apt-repository.list > /dev/null 
+
+RUN apt update
+RUN apt install carma-clock-1
+
+
+RUN apt-get update && apt-get install -y \
+    git \
+    bash \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root/dev_ws/src
+RUN git clone https://github.com/usdot-fhwa-stol/carma-time-lib.git -b develop
+WORKDIR /carma-time-lib
+
+RUN chmod +x ./install_dependencies.sh
+RUN cmake -Bbuild -DBUILD_PYTHON_BINDINGS=ON .
+RUN cmake --build build
+
+
+ADD cda-mmitss /cda-mmitss
+
+ENTRYPOINT ["/usr/bin/supervisord", "--configuration=/nojournal/bin/supervisord.conf"]
+


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

Add one Dockerfile.carma_time_lib file into the mmitss/build/dockerfiles/x86 directiory.

## Related GitHub Issue

None

## Related Jira Key

TT129

## Motivation and Context

Include the time lib installation in mmitss dockerfile so as to utilize time-lib functions in mmitss

## How Has This Been Tested?

Not tested yet

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
